### PR TITLE
Added buttons connected to rows

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,8 @@ function takeTurn () {
 
 }
 
+
+
 const App = () => {
   return (
     <div className={style.app}>

--- a/src/Components/ButtonRow/ButtonRow.module.css
+++ b/src/Components/ButtonRow/ButtonRow.module.css
@@ -1,0 +1,5 @@
+.button-row {
+    display: flex; /* Align the buttons horizontally in a row */
+    justify-content: center; /* Center the buttons horizontally within the row */
+    gap: 10px; /* Space between buttons */
+  }

--- a/src/Components/ButtonRow/index.jsx
+++ b/src/Components/ButtonRow/index.jsx
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types';
+import style from './ButtonRow.module.css'
+import ColumnButton from '../ColumnButton';
+const ButtonRow = ({cols, onColumnClick}) => {
+    return (
+        <div className={style["button-row"]}>
+            {Array.from({length:cols}).map((_, colIndex) => (
+                <ColumnButton
+                    key={colIndex}
+                    colIndex={colIndex}
+                    onClick={onColumnClick}
+                    >
+                    </ColumnButton>
+            ))}
+        </div>
+    );
+};
+
+ButtonRow.propTypes = {
+    cols: PropTypes.number.isRequired,
+    onColumnClick: PropTypes.func.isRequired,
+};
+
+export default ButtonRow

--- a/src/Components/ColumnButton/ColumnButton.module.css
+++ b/src/Components/ColumnButton/ColumnButton.module.css
@@ -1,0 +1,9 @@
+.column-button {
+    width: 0;
+    height: 0;
+    border-left: 20px solid transparent;
+    border-right: 20px solid transparent;
+    border-bottom: 30px solid rgb(0, 55, 254); 
+    cursor: pointer;
+    border-radius: 0; /* Remove default button border radius */
+  }

--- a/src/Components/ColumnButton/index.jsx
+++ b/src/Components/ColumnButton/index.jsx
@@ -1,0 +1,22 @@
+import style from './ColumnButton.module.css'
+import PropTypes from 'prop-types';
+
+// Creates a square for the board grid
+const ColumnButton = ({colIndex, onClick, children}) => {
+  return (
+    <button 
+        className={style["column-button"]}
+        onClick={() => onClick(colIndex)}
+     >
+        {children}
+        </button>
+  )
+};
+
+ColumnButton.propTypes = {
+    colIndex: PropTypes.number.isRequired, // Ensure colIndex is a number
+    onClick: PropTypes.func.isRequired, // Ensure onClick is a function
+    children: PropTypes.node, // Allow any valid children (like text or JSX)
+  };
+  
+export default ColumnButton;

--- a/src/Components/Grid/index.jsx
+++ b/src/Components/Grid/index.jsx
@@ -1,6 +1,6 @@
 import style from './Grid.module.css';
 import GridSquare from "../GridSquare";
-import ButtonRow from './Components/ButtonRow';
+import ButtonRow from "../ButtonRow/index"
 
 const ROWS = 6;
 const COLS = 7;

--- a/src/Components/Grid/index.jsx
+++ b/src/Components/Grid/index.jsx
@@ -1,15 +1,20 @@
 import style from './Grid.module.css';
 import GridSquare from "../GridSquare";
-
+import ButtonRow from './Components/ButtonRow';
 
 const ROWS = 6;
 const COLS = 7;
 
 let grid = Array(ROWS).fill(Array(COLS).fill(null));
 
+const handleColumnClick =(colIndex) => {
+  console.log(`Column ${colIndex + 1} button clicked`)
+}
 
 const Grid = () => {
   return (
+    <>
+    <ButtonRow cols={COLS} onColumnClick={handleColumnClick}/>
     <div className={style.grid}>
       {grid.map((row, rowIndex) => (
         <div key={rowIndex} className={style.row}>
@@ -19,6 +24,7 @@ const Grid = () => {
         </div>
       ))}
     </div>
+    </>
   )
 }
 


### PR DESCRIPTION
This PR adds buttons that can be pressed. You may have to run "npm install" for the PropTypes library

![Connect 4 grid buttons](https://github.com/user-attachments/assets/90e4aa94-0128-43df-8f2a-e59b748d239e)
